### PR TITLE
Make social share mobile friendly

### DIFF
--- a/src/components/utility/SocialShareToolbar.scss
+++ b/src/components/utility/SocialShareToolbar.scss
@@ -38,7 +38,7 @@
         padding: 5px;
       }
 
-      .SocialMediaShareButton{
+      .SocialMediaShareButton {
         &:active, &:hover, &:focus {
           opacity: 0.5;
           cursor: pointer;

--- a/src/components/utility/SocialShareToolbar.scss
+++ b/src/components/utility/SocialShareToolbar.scss
@@ -1,3 +1,5 @@
+@import '../../style/breakpoints';
+
 .SocialShareToolbar {
 
   &__dropdown {
@@ -5,12 +7,21 @@
     position: relative;
 
     &__button {
-
+      svg {
+        margin: 2px;
+      }
+      span {
+        @media(max-width: $xs-to-sm) {
+          display: none;
+        }
+      }
     }
 
     &__content {
       margin-top: 3px;
-      right: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-left: auto;
       display: none;
       position: absolute;
       background-color: var(--button-bg-color);
@@ -25,6 +36,13 @@
 
       &__item {
         padding: 5px;
+      }
+
+      .SocialMediaShareButton{
+        &:active, &:hover, &:focus {
+          opacity: 0.5;
+          cursor: pointer;
+        }
       }
     }
   }

--- a/src/components/utility/Toolbar.scss
+++ b/src/components/utility/Toolbar.scss
@@ -42,5 +42,16 @@
     > * + * {
       margin-left: 10px;
     }
+
+    .Button {
+      svg {
+        margin: 2px;
+      }
+      span {
+        @media(max-width: $xs-to-sm) {
+          display: none;
+        }
+      }
+    }
   }
 }

--- a/src/style/breakpoints.scss
+++ b/src/style/breakpoints.scss
@@ -1,4 +1,4 @@
-$xs: 480px;
+$xs: 400px;
 $xs-to-sm: 600px;
 $sm-to-md: 900px;
 $md-to-lg: 1200px;


### PR DESCRIPTION
In Image Edit: 
- Only display toolbar icons on mobile
- Style social share dropdown to be centered under the button
